### PR TITLE
gip-1/treasury-and-lp-incentives:

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Fully decentralized self-stabilizing gold, guided by a DAO.
 
 ## contracts
 ### mainnet
-- `0x227bfdba783ba490bfa012d68d22165fde35ab90` **DAO**
+- `0xda4a90c4d06e2384148a2e67e44a504a8f555f54` **DAO Proxy**
+- `0x7C41a5365aB4aD87CAeFdCFD2841b517CD0cBF63` **Implementation**
 - `0x5cf9242493be1411b93d064ca2e468961bbb5924` **Gold**
 - `0x6944eb48b1760c6613d54e4fa0d892154c76aea7` **Oracle**
 - `0x94926da4c34c3a379426b51af154fcbf24c2026a` **UniswapV2 sXAU:ESG Pair**

--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -52,11 +52,9 @@ library Constants {
     /* Regulator */
     uint256 private constant SUPPLY_CHANGE_LIMIT = 1e17; // 10%
     uint256 private constant COUPON_SUPPLY_CHANGE_LIMIT = 6e16; // 6%
-    uint256 private constant ORACLE_POOL_RATIO = 20; // 20%
-    uint256 private constant TREASURY_RATIO = 250; // 2.5%, until TREASURY_ADDRESS is set, this portion is sent to LP
-
-    // TODO: vote on recipient
-    address private constant TREASURY_ADDRESS = address(0x0000000000000000000000000000000000000000);
+    uint256 private constant ORACLE_POOL_RATIO = 30; // 30%
+    uint256 private constant TREASURY_RATIO = 250; // 2.5%
+    address private constant TREASURY_ADDRESS = address(0xd62ca03796A3242aFc585566618Aa4c52f4E155D);
 
     /* Deployer account vesting */
     address private constant DEPLOYER_ADDRESS = address(0xddBA37Bb29E55eDd28f5fdaEfbe5D3dF0F60909C);

--- a/protocol/contracts/dao/Bonding.sol
+++ b/protocol/contracts/dao/Bonding.sol
@@ -77,16 +77,4 @@ contract Bonding is Setters, Permission {
 
         emit Unbond(msg.sender, epoch().add(1), balance, value);
     }
-
-    function burnDeployerStake(uint256 percentage) internal {
-        address deployer = getDeployerAddress();
-        uint256 currentBalance = balanceOfBonded(deployer);
-        uint256 burnable = currentBalance.mul(percentage).div(100);
-        uint256 burnableShares = burnable.mul(totalSupply()).div(totalBonded());
-
-        // Deliberately not performing incrementBalanceOfStaged
-        decrementTotalBonded(burnable, "Bonding: insufficient total bonded");
-        decrementBalanceOf(deployer, burnableShares, "Bonding: insufficient balance");
-        gold().burn(burnable);
-    }
 }

--- a/protocol/contracts/dao/Comptroller.sol
+++ b/protocol/contracts/dao/Comptroller.sol
@@ -130,7 +130,7 @@ contract Comptroller is Setters {
 
     function mintToTreasury(uint256 amount) private {
         if (amount > 0) {
-            gold().mint(getTreasuryAddress(), amount);
+            gold().mint(Constants.getTreasuryAddress(), amount);
         }
     }
 

--- a/protocol/contracts/dao/Getters.sol
+++ b/protocol/contracts/dao/Getters.sol
@@ -170,10 +170,6 @@ contract Getters is State {
         return Constants.getDeployerAddress();
     }
 
-    function getTreasuryAddress() public view returns (address) {
-        return Constants.getTreasuryAddress();
-    }
-
     function deployerLockupEnded() public view returns (bool) {
         return blockTimestamp() >= Constants.getDeployerLockupEnd();
     }

--- a/protocol/contracts/dao/Getters.sol
+++ b/protocol/contracts/dao/Getters.sol
@@ -170,6 +170,10 @@ contract Getters is State {
         return Constants.getDeployerAddress();
     }
 
+    function getTreasuryAddress() public view returns (address) {
+        return Constants.getTreasuryAddress();
+    }
+
     function deployerLockupEnded() public view returns (bool) {
         return blockTimestamp() >= Constants.getDeployerLockupEnd();
     }

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -16,7 +16,7 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
     event Incentivization(address indexed account, uint256 amount);
 
     function initialize() initializer public {
-        mintToAccount(getTreasuryAddress(), 100e18);
+        mintToAccount(Constants.getTreasuryAddress(), 100e18);
     }
 
     function advance() external {

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -16,8 +16,7 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
     event Incentivization(address indexed account, uint256 amount);
 
     function initialize() initializer public {
-        // Remove call and delete function during next upgrade
-        burnDeployerStake(70);
+        mintToAccount(getTreasuryAddress(), 100e18);
     }
 
     function advance() external {

--- a/protocol/contracts/mock/MockBonding.sol
+++ b/protocol/contracts/mock/MockBonding.sol
@@ -20,10 +20,6 @@ contract MockBonding is MockComptroller, Bonding {
         return deployerAddress;
     }
 
-    function burnDeployerStakeE(uint256 percent) external {
-        super.burnDeployerStake(percent);
-    }
-
     function setBlockTimestamp(uint256 time) external {
         timestamp = time;
     }

--- a/protocol/test/dao/Market.test.js
+++ b/protocol/test/dao/Market.test.js
@@ -433,7 +433,7 @@ describe('Market', function () {
         expect(event.args.couponsExpired).to.be.bignumber.equal(new BN(103703));
         expect(event.args.lessRedeemable).to.be.bignumber.equal(new BN(100000));
         expect(event.args.lessDebt).to.be.bignumber.equal(new BN(0));
-        expect(event.args.newBonded).to.be.bignumber.equal(new BN(22500));
+        expect(event.args.newBonded).to.be.bignumber.equal(new BN(32500));
       });
     });
 

--- a/protocol/test/dao/Regulator.test.js
+++ b/protocol/test/dao/Regulator.test.js
@@ -7,9 +7,9 @@ const MockRegulator = contract.fromArtifact('MockRegulator');
 const MockSettableOracle = contract.fromArtifact('MockSettableOracle');
 const Gold = contract.fromArtifact('Gold');
 
-const POOL_REWARD_PERCENT = 20;
+const POOL_REWARD_PERCENT = 30;
 const TREASURY_REWARD_BIPS = 250;
-const TREASURY_ADDRESS = '0x412D82fd4062AEEd750d1654c64985CDbA0F11b7';
+const TREASURY_ADDRESS = '0xd62ca03796A3242aFc585566618Aa4c52f4E155D';
 
 function lessPoolAndTreasuryIncentive(baseAmount, newAmount) {
   return new BN(baseAmount + newAmount - poolIncentive(newAmount) - treasuryIncentive(newAmount));
@@ -62,8 +62,8 @@ describe('Regulator', function () {
           it('mints new Gold tokens', async function () {
             expect(await this.gold.totalSupply()).to.be.bignumber.equal(new BN(1000000).add(new BN(this.expectedReward)));
             expect(await this.gold.balanceOf(this.regulator.address)).to.be.bignumber.equal(lessPoolAndTreasuryIncentive(1000000, this.expectedReward));
-            expect(await this.gold.balanceOf(poolAddress)).to.be.bignumber.equal(poolIncentive(this.expectedReward).add(treasuryIncentive(this.expectedReward)));
-            // expect(await this.gold.balanceOf(TREASURY_ADDRESS)).to.be.bignumber.equal(treasuryIncentive(this.expectedReward));
+            expect(await this.gold.balanceOf(poolAddress)).to.be.bignumber.equal(poolIncentive(this.expectedReward));
+            expect(await this.gold.balanceOf(TREASURY_ADDRESS)).to.be.bignumber.equal(treasuryIncentive(this.expectedReward));
           });
 
           it('updates totals', async function () {
@@ -107,8 +107,8 @@ describe('Regulator', function () {
           it('mints new Gold tokens', async function () {
             expect(await this.gold.totalSupply()).to.be.bignumber.equal(new BN(1000000).add(new BN(this.expectedReward)));
             expect(await this.gold.balanceOf(this.regulator.address)).to.be.bignumber.equal(lessPoolAndTreasuryIncentive(1000000, this.expectedReward));
-            expect(await this.gold.balanceOf(poolAddress)).to.be.bignumber.equal(poolIncentive(this.expectedReward).add(treasuryIncentive(this.expectedReward)));
-            // expect(await this.gold.balanceOf(TREASURY_ADDRESS)).to.be.bignumber.equal(treasuryIncentive(this.expectedReward));
+            expect(await this.gold.balanceOf(poolAddress)).to.be.bignumber.equal(poolIncentive(this.expectedReward));
+            expect(await this.gold.balanceOf(TREASURY_ADDRESS)).to.be.bignumber.equal(treasuryIncentive(this.expectedReward));
           });
 
           it('updates totals', async function () {
@@ -149,9 +149,9 @@ describe('Regulator', function () {
           beforeEach(async function () {
             await this.oracle.set(101, 100, true);
             this.expectedReward = 10000;
-            this.expectedRewardCoupons = 7750;
+            this.expectedRewardCoupons = 6750;
             this.expectedRewardDAO = 0;
-            this.expectedRewardLP = 2000;
+            this.expectedRewardLP = 3000;
             this.expectedRewardTreasury = 250;
 
             this.result = await this.regulator.stepE();
@@ -161,8 +161,8 @@ describe('Regulator', function () {
           it('mints new Gold tokens', async function () {
             expect(await this.gold.totalSupply()).to.be.bignumber.equal(new BN(1000000).add(new BN(this.expectedReward)));
             expect(await this.gold.balanceOf(this.regulator.address)).to.be.bignumber.equal(new BN(1000000).add(new BN(this.expectedRewardCoupons)));
-            expect(await this.gold.balanceOf(poolAddress)).to.be.bignumber.equal(new BN(this.expectedRewardLP).add(new BN(this.expectedRewardTreasury)));
-            // expect(await this.gold.balanceOf(TREASURY_ADDRESS)).to.be.bignumber.equal(new BN(this.expectedRewardTreasury));
+            expect(await this.gold.balanceOf(poolAddress)).to.be.bignumber.equal(new BN(this.expectedRewardLP));
+            expect(await this.gold.balanceOf(TREASURY_ADDRESS)).to.be.bignumber.equal(new BN(this.expectedRewardTreasury));
           });
 
           it('updates totals', async function () {
@@ -204,9 +204,9 @@ describe('Regulator', function () {
       describe('on step', function () {
         beforeEach(async function () {
           await this.oracle.set(101, 100, true);
-          this.bondedReward = 5750;
+          this.bondedReward = 4750;
           this.newRedeemable = 2000;
-          this.poolReward = 2000;
+          this.poolReward = 3000;
           this.treasuryReward = 250;
 
           this.result = await this.regulator.stepE();
@@ -216,8 +216,8 @@ describe('Regulator', function () {
         it('mints new Gold tokens', async function () {
           expect(await this.gold.totalSupply()).to.be.bignumber.equal(new BN(1010000));
           expect(await this.gold.balanceOf(this.regulator.address)).to.be.bignumber.equal(new BN(1000000 + this.newRedeemable + this.bondedReward));
-          expect(await this.gold.balanceOf(poolAddress)).to.be.bignumber.equal(new BN(this.poolReward).add(new BN(this.treasuryReward)));
-          // expect(await this.gold.balanceOf(TREASURY_ADDRESS)).to.be.bignumber.equal(new BN(this.treasuryReward));
+          expect(await this.gold.balanceOf(poolAddress)).to.be.bignumber.equal(new BN(this.poolReward));
+          expect(await this.gold.balanceOf(TREASURY_ADDRESS)).to.be.bignumber.equal(new BN(this.treasuryReward));
         });
 
         it('updates totals', async function () {
@@ -258,9 +258,9 @@ describe('Regulator', function () {
           beforeEach(async function () {
             await this.oracle.set(105, 100, true);
             this.expectedReward = 50000;
-            this.expectedRewardCoupons = 38750;
+            this.expectedRewardCoupons = 33750;
             this.expectedRewardDAO = 0;
-            this.expectedRewardLP = 10000;
+            this.expectedRewardLP = 15000;
             this.expectedRewardTreasury = 1250;
 
             this.result = await this.regulator.stepE();
@@ -270,8 +270,8 @@ describe('Regulator', function () {
           it('mints new Gold tokens', async function () {
             expect(await this.gold.totalSupply()).to.be.bignumber.equal(new BN(1000000).add(new BN(this.expectedReward)));
             expect(await this.gold.balanceOf(this.regulator.address)).to.be.bignumber.equal(new BN(1000000).add(new BN(this.expectedRewardCoupons)));
-            expect(await this.gold.balanceOf(poolAddress)).to.be.bignumber.equal(new BN(this.expectedRewardLP).add(new BN(this.expectedRewardTreasury)));
-            // expect(await this.gold.balanceOf(TREASURY_ADDRESS)).to.be.bignumber.equal(new BN(this.expectedRewardTreasury));
+            expect(await this.gold.balanceOf(poolAddress)).to.be.bignumber.equal(new BN(this.expectedRewardLP));
+            expect(await this.gold.balanceOf(TREASURY_ADDRESS)).to.be.bignumber.equal(new BN(this.expectedRewardTreasury));
           });
 
           it('updates totals', async function () {

--- a/protocol/test/dao/Vesting.test.js
+++ b/protocol/test/dao/Vesting.test.js
@@ -79,35 +79,6 @@ describe('Deployer Contract Vesting/Burn Mechanism', () => {
         );
     })
 
-    it('should burn 70% of the deployer stake and ESG in response to burnDeployerStake()', async () => {
-        const seventyPercent = new BN(70);
-        await self.bonding.burnDeployerStakeE(seventyPercent, {from: userC});
-
-        const deployerSharePostBurn = INITIAL_STAKE_MULTIPLE.mul(new BN(3));
-        const userAShare = INITIAL_STAKE_MULTIPLE.mul(new BN(2));
-        const userBShare = INITIAL_STAKE_MULTIPLE.mul(new BN(1));
-
-        expect(await self.bonding.totalBonded()).to.be.bignumber.equal(
-            new BN(3).add(new BN(2)).add(new BN(1))
-        );
-
-        expect(await self.bonding.totalSupply()).to.be.bignumber.equal(
-            deployerSharePostBurn.add(userAShare).add(userBShare)
-        );
-
-        expect(await self.gold.totalSupply()).to.be.bignumber.equal(
-            new BN(3).add(new BN(2)).add(new BN(1)).add(new BN(additionalCirculatingUser.initialBalance))
-        );
-
-        expect(await self.gold.balanceOf(additionalCirculatingUser.acc)).to.be.bignumber.equal(
-            new BN(additionalCirculatingUser.initialBalance)
-        );
-
-        expect(await self.bonding.balanceOf(deployerAddress)).to.be.bignumber.equal(deployerSharePostBurn)
-        expect(await self.bonding.balanceOf(userA)).to.be.bignumber.equal(userAShare)
-        expect(await self.bonding.balanceOf(userB)).to.be.bignumber.equal(userBShare)
-    })
-
     it('should allow users to unbond their balance', async () => {
         for (const {acc, unbondAmount} of [{acc: userA, unbondAmount: 2}, {acc: userB, unbondAmount: 1}]) {
             const unbondResult = await this.bonding.unbondUnderlying(unbondAmount, {from: acc})
@@ -137,15 +108,15 @@ describe('Deployer Contract Vesting/Burn Mechanism', () => {
     })
 
     it('should not allow the deployer to unbond before the vesting deadline', async () => {
-        await expectRevert(this.bonding.unbondUnderlying(3, {from: deployerAddress}), "Permission: Unlocked after 2021-06-01")
+        await expectRevert(this.bonding.unbondUnderlying(10, {from: deployerAddress}), "Permission: Unlocked after 2021-06-01")
         await self.bonding.setBlockTimestamp(DEPLOYER_LOCKUP_END + (21600 * 2));
 
-        const unbondResult = await this.bonding.unbondUnderlying(3, {from: deployerAddress});
+        const unbondResult = await this.bonding.unbondUnderlying(10, {from: deployerAddress});
         const event = await expectEvent.inTransaction(unbondResult.tx, MockBonding, 'Unbond', {
             account: deployerAddress
         });
 
-        expect(event.args.value).to.be.bignumber.equal(new BN(3).mul(INITIAL_STAKE_MULTIPLE));
-        expect(event.args.valueUnderlying).to.be.bignumber.equal(new BN(3));
+        expect(event.args.value).to.be.bignumber.equal(new BN(10).mul(INITIAL_STAKE_MULTIPLE));
+        expect(event.args.valueUnderlying).to.be.bignumber.equal(new BN(10));
     })
 });


### PR DESCRIPTION
### Background

It has become standard in the wider space to have a community treasury consisting of individuals with a reputational stake in handling those funds in a good faith manner.  Before we venture in to protocol changes which will take 1-2 weeks at a time to complete, we would like to propose that we bootstrap our treasury, and direct treasury rewards of 2.5% per expansion to a multisig controlled by members of the community.

Following conversations in the Discord, it was also decided that increasing LP rewards to 30% would be beneficial in drawing in liquidity providers. 

**NOTE:** The gnosis safe does not currently have all members added and is currently 2/3 signatories.  This should be rectified prior to deployment for voting. 

**Implementation:** 
1. Set treasury address to gnosis multisig.
2. Seed the treasury with (roughly) an amount of ESG equivalent to that burned in the previous GIP. 
3. Increase LP reward share to 30%.

**Misc/Cleanup:** 
1. Cleanup of code related to previous GIP
2. Removed `if` statement sending additional rewards to LP in place of treasury.  Treasury will remain on from now on, so that test is not needed anymore. 